### PR TITLE
Support databricks 6.5.0 operator

### DIFF
--- a/apache-airflow-granulate-databricks/apache_airflow_granulate_databricks/__init__.py
+++ b/apache-airflow-granulate-databricks/apache_airflow_granulate_databricks/__init__.py
@@ -9,7 +9,8 @@ __all__ = ["__version__"]
 __version__ = version("apache_airflow_granulate_databricks")
 
 MIN_DBX_PROVIDER_SUPPORTED_VERSION = "4.2.0"
-MAX_DBX_PROVIDER_SUPPORTED_VERSION = "6.0.0"
+MAX_DBX_PROVIDER_SUPPORTED_VERSION = "6.5.0"
+
 
 try:
     from airflow.providers.databricks import __version__ as airflow_dbx_version

--- a/apache-airflow-granulate-databricks/apache_airflow_granulate_databricks/granulate_plugin.py
+++ b/apache-airflow-granulate-databricks/apache_airflow_granulate_databricks/granulate_plugin.py
@@ -5,8 +5,10 @@ import inspect
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Type
 
+from airflow import __version__ as airflow_version
 from airflow.models import BaseOperator
 from airflow.plugins_manager import AirflowPlugin
+from airflow.providers.databricks import __version__ as airflow_dbx_version
 from airflow.providers.databricks.operators.databricks import (
     DatabricksSubmitRunDeferrableOperator,
     DatabricksSubmitRunOperator,
@@ -21,13 +23,21 @@ GRANULATE_JOB_NAME_KEY: str = "GRANULATE_JOB_NAME"
 GRANULATE_JOB_NAME_VALUE: str = "{{ task.task_id }}_{{ task.dag_id }}"
 
 
-def _add_granulate_env_vars_to_cluster(new_cluster: Dict[str, Any]) -> Dict[str, Any]:
+def _add_granulate_env_vars_to_cluster(
+    new_cluster: Dict[str, Any], granulate_job_name_value: Optional[str] = None
+) -> Dict[str, Any]:
     """
     Adds Granulate environment variables to the new_cluster dictionary.
     If new_cluster is None, initializes it with the required structure.
     """
+    if granulate_job_name_value is not None:
+        new_cluster.setdefault("spark_env_vars", {})[GRANULATE_JOB_NAME_KEY] = granulate_job_name_value
+    else:
+        new_cluster.setdefault("spark_env_vars", {})[GRANULATE_JOB_NAME_KEY] = GRANULATE_JOB_NAME_VALUE
 
-    new_cluster.setdefault("spark_env_vars", {})[GRANULATE_JOB_NAME_KEY] = GRANULATE_JOB_NAME_VALUE
+    new_cluster["spark_env_vars"]["GRANULATE_AIRFLOW_VERSION"] = str(airflow_version)
+    new_cluster["spark_env_vars"]["GRANULATE_AIRFLOW_DATABRICKS_PLUGIN_VERSION"] = str(airflow_dbx_version)
+    logger.info(f"Added Granulate environment variables to the cluster: {new_cluster}")
     return new_cluster
 
 
@@ -85,9 +95,9 @@ def patch() -> None:
         def granulate_execute(self: Any, context: Context, original_execute: Callable[..., Any]) -> Any:
             try:
                 if "new_cluster" in self.json:
-                    self.json["new_cluster"].setdefault("spark_env_vars", {})[
-                        GRANULATE_JOB_NAME_KEY
-                    ] = f"{self.task_id}_{self.dag.dag_id}"
+                    _add_granulate_env_vars_to_cluster(
+                        self.json["new_cluster"], granulate_job_name_value=f"{self.task_id}_{self.dag.dag_id}"
+                    )
                 else:
                     self.log.info("Operator's json doesn't contain `new_cluster`, skip patching")
 

--- a/apache-airflow-granulate-databricks/apache_airflow_granulate_databricks/granulate_plugin.py
+++ b/apache-airflow-granulate-databricks/apache_airflow_granulate_databricks/granulate_plugin.py
@@ -37,7 +37,6 @@ def _add_granulate_env_vars_to_cluster(
 
     new_cluster["spark_env_vars"]["GRANULATE_AIRFLOW_VERSION"] = str(airflow_version)
     new_cluster["spark_env_vars"]["GRANULATE_AIRFLOW_DATABRICKS_PLUGIN_VERSION"] = str(airflow_dbx_version)
-    logger.info(f"Added Granulate environment variables to the cluster: {new_cluster}")
     return new_cluster
 
 

--- a/apache-airflow-granulate-databricks/pyproject.toml
+++ b/apache-airflow-granulate-databricks/pyproject.toml
@@ -8,6 +8,9 @@ license = "LICENSE"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
+# docutils 0.21 cannot be installed with poetry
+# See https://github.com/python-poetry/poetry/issues/9293
+docutils = "!=0.21"
 importlib-metadata = "*"
 apache-airflow-granulate-databricks-auto-patch = {version = "0.1.0", optional = true}
 

--- a/apache-airflow-granulate-databricks/pyproject.toml
+++ b/apache-airflow-granulate-databricks/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 license = "LICENSE"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.8,<3.13"
 # docutils 0.21 cannot be installed with poetry
 # See https://github.com/python-poetry/poetry/issues/9293
 docutils = "!=0.21"

--- a/apache-airflow-granulate-databricks/pyproject.toml
+++ b/apache-airflow-granulate-databricks/pyproject.toml
@@ -13,8 +13,8 @@ apache-airflow-granulate-databricks-auto-patch = {version = "0.1.0", optional = 
 
 
 [tool.poetry.group.dev.dependencies]
-apache-airflow= "2.8.1"
-apache-airflow-providers-databricks = "6.0.0"
+apache-airflow= "2.9.2"
+apache-airflow-providers-databricks = "6.5.0"
 mypy = "^1.1.1"
 ruff = "^0.1.6"
 


### PR DESCRIPTION
This PR changes a few things

- Add Support for Databricks Operator version 6.5.0 and latest Airflow version (2.9.2)
- Pass Databricks airflow plugin version and general airflow version as another env params